### PR TITLE
don't ship tests in %sitelib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('requirements.txt') as f:
 setup(
     name = "docker-scripts",
     version = version.version,
-    packages = find_packages(),
+    packages = find_packages(exclude=["tests"]),
     url = 'https://github.com/goldmann/docker-scripts',
     download_url = "https://github.com/goldmann/docker-scripts/archive/%s.tar.gz" % version.version,
     author = 'Marek Goldmann',


### PR DESCRIPTION
Current `setup.py` will ship `tests` in `/usr/lib/python2.7/site-packages/tests/`. Let's not do that.