### PR TITLE
mimic docker's behaviour when creating tars

### DIFF
--- a/docker_scripts/squash.py
+++ b/docker_scripts/squash.py
@@ -195,7 +195,15 @@ class Squash(object):
         with tarfile.open(output_path, 'w') as tar:
             self.log.debug("Generating tar archive for the squashed image...")
             with Chdir(directory):
-                tar.add(".")
+                # docker produces images like this:
+                #   repositories
+                #   <layer>/json
+                # and not:
+                #   ./
+                #   ./repositories
+                #   ./<layer>/json
+                for f in os.listdir("."):
+                    tar.add(f)
             self.log.debug("Archive generated")
 
     def _load_image(self, directory):


### PR DESCRIPTION
docker produces tars like this:

156aa6242d2f1f508674edee8f71458ef11a42a923af69c832e9cd6cb30c5c56/
156aa6242d2f1f508674edee8f71458ef11a42a923af69c832e9cd6cb30c5c56/json
156aa6242d2f1f508674edee8f71458ef11a42a923af69c832e9cd6cb30c5c56/VERSION
156aa6242d2f1f508674edee8f71458ef11a42a923af69c832e9cd6cb30c5c56/layer.tar
repositories

while tarball after squashing looks like this

./
./repositories
./10acc31def5d6f249b548e01e8ffbaccfd61af0240c17315a7ad393d022c5ca2/
./10acc31def5d6f249b548e01e8ffbaccfd61af0240c17315a7ad393d022c5ca2/json
./10acc31def5d6f249b548e01e8ffbaccfd61af0240c17315a7ad393d022c5ca2/VERSION
./10acc31def5d6f249b548e01e8ffbaccfd61af0240c17315a7ad393d022c5ca2/layer.tar

Fixes #30