### PR TITLE
Exit gracefully if no image is provided

### DIFF
--- a/docker_scripts/squash.py
+++ b/docker_scripts/squash.py
@@ -389,6 +389,9 @@ class Squash(object):
         self.log.info("Squashing finished!")
 
     def run(self):
+        if self.image is None:
+            self.log.error("Image is not provided, exiting")
+            sys.exit(1)
 
         self.log.info("Squashing image '%s'..." % self.image)
 

--- a/tests/test_unit_squash.py
+++ b/tests/test_unit_squash.py
@@ -268,6 +268,18 @@ class TestAddMarkers(unittest.TestCase):
 
         self.assertTrue(len(tar.addfile.mock_calls) == 0)
 
+class TestGeneral(unittest.TestCase):
+
+    def setUp(self):
+        self.docker_client = mock.Mock()
+        self.log = mock.Mock()
+
+    def test_handle_case_when_no_image_is_provided(self):
+        squash = Squash(self.log, None, self.docker_client)
+        with self.assertRaises(SystemExit) as cm:
+            squash.run()
+        self.assertEqual(cm.exception.code, 1)
+        self.log.error.assert_called_with("Image is not provided, exiting")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This happens only when the squashing tool is executed programmatically.

Fixes #36.