### PR TITLE
bug: use version import properly

### DIFF
--- a/docker_scripts/cli.py
+++ b/docker_scripts/cli.py
@@ -82,7 +82,7 @@ class CLI(object):
         else:
             self.log.setLevel(logging.INFO)
 
-        self.log.debug("Running version %s", version.version)
+        self.log.debug("Running version %s", version)
 
         args.func(args)
 


### PR DESCRIPTION
I am facepalming hard. Not sure how could I miss that.

```
$ python ./docker_scripts/cli.py squash cb41ae3abead
Traceback (most recent call last):
  File "./docker_scripts/cli.py", line 96, in <module>
    run()
  File "./docker_scripts/cli.py", line 92, in run
    cli.run()
  File "./docker_scripts/cli.py", line 85, in run
    self.log.debug("Running version %s", version.version)
AttributeError: 'str' object has no attribute 'version'
```