### PR TITLE
Add --development switch

### DIFF
--- a/docker_scripts/cli.py
+++ b/docker_scripts/cli.py
@@ -29,7 +29,7 @@ class CLI(object):
 
     def run_squash(self, args):
         squash.Squash(log=self.log, image=args.image,
-                      from_layer=args.from_layer, tag=args.tag, output_path=args.output_path, tmp_dir=args.tmp_dir).run()
+                      from_layer=args.from_layer, tag=args.tag, output_path=args.output_path, tmp_dir=args.tmp_dir, development=args.development).run()
 
     def run_layers(self, args):
         layers.Layers(log=self.log, image=args.image,
@@ -53,7 +53,9 @@ class CLI(object):
         parser_squash.set_defaults(func=self.run_squash)
         parser_squash.add_argument('image', help='Image to be squashed')
         parser_squash.add_argument(
-            '-f', '--from-layer', help='ID of the layer or image ID or image name. If not specified will squash up to last layer (FROM instruction)')
+            '-d', '--development', action='store_true', help='Does not clean up after failure for easier debugging')
+        parser_squash.add_argument(
+            '-f', '--from-layer', help='ID of the layer or image ID or image name. If not specified will squash all layers in the image')
         parser_squash.add_argument(
             '-t', '--tag', help="Specify the tag to be used for the new image. By default it'll be set to 'image' argument")
         parser_squash.add_argument(
@@ -88,7 +90,12 @@ class CLI(object):
         try:
             args.func(args)
         except Error as e:
-            self.log.exception(e)
+            if args.development or args.verbose:
+                self.log.exception(e)
+            else:
+                self.log.error(e.message)
+                self.log.error("Squashing failed, exiting. If you think this is our fault, please open a new issue: https://github.com/goldmann/docker-scripts/issues, thanks!")
+
             sys.exit(1)
 
 

--- a/docker_scripts/cli.py
+++ b/docker_scripts/cli.py
@@ -94,7 +94,8 @@ class CLI(object):
                 self.log.exception(e)
             else:
                 self.log.error(e.message)
-                self.log.error("Squashing failed, exiting. If you think this is our fault, please open a new issue: https://github.com/goldmann/docker-scripts/issues, thanks!")
+                self.log.error(
+                    "Squashing failed, if you think this is our fault, please file an issue: https://github.com/goldmann/docker-scripts/issues, thanks!")
 
             sys.exit(1)
 

--- a/docker_scripts/image.py
+++ b/docker_scripts/image.py
@@ -73,8 +73,10 @@ class Image(object):
         pass
 
     def cleanup(self):
-        # Cleanup the temporary directory
-        shutil.rmtree(self.tmp_dir)
+        """ Cleanup the temporary directory """
+
+        self.log.debug("Cleaning up %s temporary directory" % self.tmp_dir)
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
     def _initialize_directories(self):
         # Prepare temporary directory where all the work will be executed

--- a/docker_scripts/squash.py
+++ b/docker_scripts/squash.py
@@ -14,7 +14,7 @@ from docker_scripts.version import version
 class Squash(object):
 
     def __init__(self, log, image, docker=None, from_layer=None, tag=None, tmp_dir=None,
-                 output_path=None, load_image=True):
+                 output_path=None, load_image=True, development=False):
         self.log = log
         self.docker = docker
         self.image = image
@@ -23,6 +23,7 @@ class Squash(object):
         self.tmp_dir = tmp_dir
         self.output_path = output_path
         self.load_image = load_image
+        self.development = development
 
         if not docker:
             self.docker = common.docker_client()
@@ -53,6 +54,18 @@ class Squash(object):
 
         self.log.info("Using %s image format" % image.FORMAT)
 
+        try:
+            return self.squash(image)
+        except Exception as e:
+            # https://github.com/goldmann/docker-scripts/issues/44
+            # If development mode is not enabled, make sure we clean up the
+            # temporary directory
+            if not self.development:
+                image.cleanup()
+
+            raise
+
+    def squash(self, image):
         # Do the actual squashing
         new_image_id = image.squash()
 

--- a/docker_scripts/squash.py
+++ b/docker_scripts/squash.py
@@ -11,6 +11,7 @@ from docker_scripts.lib import common
 from docker_scripts.errors import SquashError
 from docker_scripts.version import version
 
+
 class Squash(object):
 
     def __init__(self, log, image, docker=None, from_layer=None, tag=None, tmp_dir=None,
@@ -56,7 +57,7 @@ class Squash(object):
 
         try:
             return self.squash(image)
-        except Exception as e:
+        except Exception:
             # https://github.com/goldmann/docker-scripts/issues/44
             # If development mode is not enabled, make sure we clean up the
             # temporary directory


### PR DESCRIPTION
Introduce `--development` (`-d`) switch. Now it removes temporary directory in case of failure unless
`--development` is enabled.

Fixes #44